### PR TITLE
Update comparison value for Live on Listings

### DIFF
--- a/coming-soon-automation-app/comingSoonLocations/optInLocations/km/connector/updateComingSoonEligibility.json
+++ b/coming-soon-automation-app/comingSoonLocations/optInLocations/km/connector/updateComingSoonEligibility.json
@@ -240,7 +240,7 @@
             {
               "inputColumn": "Check for License Assignment",
               "comparator": "CONTAINS",
-              "comparisonValue": "true"
+              "comparisonValue": "true-true-true-true"
             }
           ]
         }


### PR DESCRIPTION
Only mark "Live on Listings" as true if "Live on Yelp", "Live on Google", "Live on Extended Network", and "Live on Facebook" are all true